### PR TITLE
Add virtual port oper-state change notification to the yang model

### DIFF
--- a/release/models/ipsec/openconfig-ipsec-offload.yang
+++ b/release/models/ipsec/openconfig-ipsec-offload.yang
@@ -35,11 +35,11 @@ module openconfig-ipsec-offload {
       the NSF is expected to implement this
       feature.";
   }
-    
+
   grouping ipsec-offload-config {
     description
       "Reusable grouping for config data";
-    
+
     leaf offload-id {
       type uint32;
       mandatory true;
@@ -65,7 +65,7 @@ module openconfig-ipsec-offload {
         IPsec SA with an IPsec policy with
         the same req-id.";
     }
-    
+
     leaf spi {
       type uint32 {
         range "0..max";
@@ -74,7 +74,7 @@ module openconfig-ipsec-offload {
       description
         "IPsec SA of Security Parameter Index (SPI).";
     }
-    
+
     leaf ext-seq-num {
       type boolean;
       default "true";
@@ -105,14 +105,14 @@ module openconfig-ipsec-offload {
         "Security protocol of IPsec SA, only
         ESP so far.";
     }
-    
+
     leaf mode {
       type ietf-nsfikec:ipsec-mode;
       default "transport";
       description
         "Tunnel or transport mode.";
     }
-    
+
     container esp-sa {
       description
         "In case the IPsec SA is an
@@ -120,14 +120,14 @@ module openconfig-ipsec-offload {
         (ESP), it is required to specify
         encryption and integrity
         algorithms and key materials.";
-      
+
       container encryption {
         description
           "Configuration of encryption or
           AEAD algorithm for IPsec
           Encapsulation Security Payload
           (ESP).";
-        
+
         leaf encryption-algorithm {
           type ietf-nsfikec:encr-alg-t;
           default "12";
@@ -137,7 +137,7 @@ module openconfig-ipsec-offload {
             algorithms, the integrity-algorithm
             leaf is not used.";
         }
-        
+
         leaf key {
           ietf-nacm:default-deny-all;
           type ietf-yang:hex-string;
@@ -153,7 +153,7 @@ module openconfig-ipsec-offload {
             this leaf.  By default, it is
             128 bits.";
         }
-        
+
         leaf key-len {
           type uint32;
           mandatory true;
@@ -168,14 +168,14 @@ module openconfig-ipsec-offload {
       }
 
     } /*container esp-sa*/
-    
+
     container sa-lifetime-hard {
       description
         "IPsec SA hard lifetime.  The action
         associated is terminate and hold.";
       uses ietf-nsfikec:lifetime;
     }
-    
+
     container sa-lifetime-soft {
       description
         "IPsec SA soft lifetime.";
@@ -188,13 +188,13 @@ module openconfig-ipsec-offload {
     description
       "Operational state representing ipsec counters and
       and statistics.";
-    
+
     /*oc-ext:operational;*/
-    
+
     container counters {
       description
         "A collection of ipsec-related statistics objects.";
-      
+
       leaf pkts-processed {
       type oc-yang:counter64;
       description
@@ -275,11 +275,11 @@ module openconfig-ipsec-offload {
 
             uses ipsec-offload-config;
           } /*config*/
-          
+
           container state {
             config false;
             uses ipsec-offload-config;
-            uses ipsec-offload-state; 
+            uses ipsec-offload-state;
           }/*container state*/
         } /*list sad-entry*/
       } /*container sad*/
@@ -348,7 +348,7 @@ module openconfig-ipsec-offload {
       type boolean;
       mandatory true;
       description
-        "Contains the destination IP address type Ipv4/Ipv6. If the value is true(1) 
+        "Contains the destination IP address type Ipv4/Ipv6. If the value is true(1)
         the address in ipv4, If the value is false the address is ipv6";
     }
 

--- a/release/models/virtual-devices/openconfig-virtual-devices.yang
+++ b/release/models/virtual-devices/openconfig-virtual-devices.yang
@@ -108,7 +108,7 @@ module openconfig-virtual-devices {
       type string;
       description
         "Device specific version
-        
+
         For e.g.: 0.95 or 1.0 for virtio";
     }
 
@@ -321,7 +321,7 @@ module openconfig-virtual-devices {
       description
         "Hardware device on the host to associate this
         virtual device with.
-        
+
         For host virtualization on an infrastructure device only.";
     }
 
@@ -330,7 +330,7 @@ module openconfig-virtual-devices {
       description
         "The virtual function on the host virtual device to
         associate this virtual device with.
-        
+
         For host virtualization on an infrastructure device only.";
     }
   }
@@ -342,13 +342,13 @@ module openconfig-virtual-devices {
   container virtual-devices {
     description
       "Enclosing container for the list of virtual devices";
-    
+
     list virtual-device {
       key "device-id";
 
       description
         "A list of virtual devices";
-      
+
       leaf device-id {
         type leafref {
           path "../config/device-id";
@@ -371,7 +371,7 @@ module openconfig-virtual-devices {
         config false;
         description
           "Operational state data at the global level";
-        
+
         uses vdevice-config;
         uses vdevice-limits;
         uses vdevice-common-state;

--- a/release/models/virtual-devices/openconfig-virtual-ports.yang
+++ b/release/models/virtual-devices/openconfig-virtual-ports.yang
@@ -22,6 +22,13 @@ module openconfig-virtual-ports {
   description
     "Model for managing virtual ports";
 
+  feature oper-status-change-notification {
+    description
+      "This feature indicates that the server supports
+      generating notifications on virtual ports operational
+      status change (UP/DOWN).";
+  }
+
   grouping vport-config {
     description
       "Configuration data for the virtual port";
@@ -468,5 +475,36 @@ module openconfig-virtual-ports {
     }
   }
 
+  notification oper-status-change {
+    if-feature "oper-status-change-notification";
+    description
+      "A virtual port operational state notification.";
+
+    leaf global-resource-id {
+      type uint32;
+      mandatory true;
+      description
+        "Identifies virtual port by global unique id.";
+    }
+
+    leaf oper-status {
+      type enumeration {
+        enum UP {
+          value 1;
+          description
+            "Ready to pass packets.";
+        }
+        enum DOWN {
+          value 2;
+          description
+            "The interface does not pass any packets.";
+        }
+      }
+      mandatory true;
+      description
+        "The current operational state of the virtual port";
+      oc-ext:telemetry-on-change;
+    }
+  }
 
 }

--- a/release/models/virtual-devices/openconfig-virtual-ports.yang
+++ b/release/models/virtual-devices/openconfig-virtual-ports.yang
@@ -11,7 +11,7 @@ module openconfig-virtual-ports {
 
   import openconfig-yang-types { prefix oc-yang; }
   import openconfig-extensions { prefix oc-ext; }
-  
+
   // meta
   organization "IPDK - Infrastructure Programming Development Kit";
 
@@ -37,8 +37,8 @@ module openconfig-virtual-ports {
       type uint32;
       description
         "A global resource ID that uniquely identifies the virtual port
-        resource. 
-        Valid Range is 16 to 2**32-1 (0-15 is reserved for non-virtual ports)"; 
+        resource.
+        Valid Range is 16 to 2**32-1 (0-15 is reserved for non-virtual ports)";
     }
 
     leaf host-id {
@@ -198,7 +198,7 @@ module openconfig-virtual-ports {
       description
         "Number of VFs being provisioned";
     }
-    
+
   }
 
   grouping vport-state {
@@ -250,13 +250,13 @@ module openconfig-virtual-ports {
       description
         "Enumerated host PCIe function bus ID";
     }
-    
+
     leaf pcie-device {
       type uint8;
       description
         "Enumerated host PCIe function device ID";
     }
-    
+
     leaf pcie-function {
       type uint8;
       description
@@ -438,7 +438,7 @@ module openconfig-virtual-ports {
   container virtual-ports {
     description
       "Enclosing container for the list of virtual ports";
-    
+
     list virtual-port {
       key "global-resource-id";
 
@@ -465,7 +465,7 @@ module openconfig-virtual-ports {
         config false;
         description
           "Operational state data at the global level";
-        
+
         uses vport-config;
         uses vport-state;
         uses vport-counters;


### PR DESCRIPTION
### Change Scope
Add virtual port status notification definition to the virtual port yang model.

  notifications:
    +---n oper-status-change {oper-status-change-notification}?
       +--ro global-resource-id    uint32
       +--ro oper-status           enumeration